### PR TITLE
fix: Support multi-part model names in ListCachedModels

### DIFF
--- a/internal/cache/manager.go
+++ b/internal/cache/manager.go
@@ -149,7 +149,7 @@ func (cm *Manager) ListCachedModels() ([]CachedModel, error) {
 			}
 
 			// Split path by filepath separator (works cross-platform)
-			// Expected structure: namespace/name/version
+			// Expected structure: namespace/name/version or namespace/repo/model/version (multi-part names)
 			parts := []string{}
 			dir := relPath
 			for dir != "." && dir != "" {
@@ -160,12 +160,21 @@ func (cm *Manager) ListCachedModels() ([]CachedModel, error) {
 				dir = filepath.Dir(dir)
 			}
 
-			// Should have exactly 3 parts: namespace, name, version
-			if len(parts) == 3 {
+			// Need at least 3 parts: namespace, name, version
+			// For multi-part names (e.g., pytorch/vision/resnet50/latest):
+			// - First part is namespace
+			// - Last part is version
+			// - Everything in between is the name (joined with /)
+			if len(parts) >= 3 {
+				namespace := parts[0]
+				version := parts[len(parts)-1]
+				// Join all parts between namespace and version as the name
+				name := filepath.Join(parts[1 : len(parts)-1]...)
+
 				models = append(models, CachedModel{
-					Namespace: parts[0],
-					Name:      parts[1],
-					Version:   parts[2],
+					Namespace: namespace,
+					Name:      name,
+					Version:   version,
 					Path:      filepath.Dir(path),
 				})
 			}


### PR DESCRIPTION
## Summary
Fixes issue where `axon list` didn't show PyTorch Hub models even though they were installed.

## Problem
The `ListCachedModels` function only handled exactly 3 path parts (`namespace/name/version`), but PyTorch Hub models have multi-part names like `pytorch/vision/resnet50/latest` (4 parts).

## Solution
Updated the function to handle 3+ parts:
- First part = namespace
- Last part = version
- Middle parts = name (joined with `/`)

## Examples
- `pytorch/vision/resnet50/latest` → namespace: `pytorch`, name: `vision/resnet50`, version: `latest`
- `hf/bert-base-uncased/latest` → namespace: `hf`, name: `bert-base-uncased`, version: `latest`

## Testing
- ✅ `axon list` now correctly shows PyTorch Hub models
- ✅ Existing models (HF, local) still work correctly
- ✅ All validation checks pass

## Related
- PyTorch Hub adapter (v1.1.0)