### PR TITLE
revert: Revert fix for multi-part model names (to be re-applied via PR)

### DIFF
--- a/internal/cache/manager.go
+++ b/internal/cache/manager.go
@@ -149,7 +149,7 @@ func (cm *Manager) ListCachedModels() ([]CachedModel, error) {
 			}
 
 			// Split path by filepath separator (works cross-platform)
-			// Expected structure: namespace/name/version or namespace/repo/model/version (multi-part names)
+			// Expected structure: namespace/name/version
 			parts := []string{}
 			dir := relPath
 			for dir != "." && dir != "" {
@@ -160,21 +160,12 @@ func (cm *Manager) ListCachedModels() ([]CachedModel, error) {
 				dir = filepath.Dir(dir)
 			}
 
-			// Need at least 3 parts: namespace, name, version
-			// For multi-part names (e.g., pytorch/vision/resnet50/latest):
-			// - First part is namespace
-			// - Last part is version
-			// - Everything in between is the name (joined with /)
-			if len(parts) >= 3 {
-				namespace := parts[0]
-				version := parts[len(parts)-1]
-				// Join all parts between namespace and version as the name
-				name := filepath.Join(parts[1 : len(parts)-1]...)
-				
+			// Should have exactly 3 parts: namespace, name, version
+			if len(parts) == 3 {
 				models = append(models, CachedModel{
-					Namespace: namespace,
-					Name:      name,
-					Version:   version,
+					Namespace: parts[0],
+					Name:      parts[1],
+					Version:   parts[2],
 					Path:      filepath.Dir(path),
 				})
 			}


### PR DESCRIPTION
## Summary
This PR reverts commit `b0196fc` that was pushed directly to main, so the fix can be properly reviewed and merged via PR #10.

## Why
The fix was pushed directly to main, bypassing the PR process. This revert removes it from main so it can be properly reviewed and merged via PR #10.

## Related
- PR #10: fix: Support multi-part model names in ListCachedModels

After this is merged, PR #10 can be merged to re-apply the fix through the proper review process.