### PR TITLE
fix: Update info command to use adapter system

### DIFF
--- a/cmd/axon/commands.go
+++ b/cmd/axon/commands.go
@@ -197,11 +197,11 @@ func infoCmd() *cobra.Command {
 			fmt.Printf("\n📦 Model Information\n")
 			fmt.Printf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n")
 			fmt.Printf("Name:        %s/%s@%s\n", manifest.Metadata.Namespace, manifest.Metadata.Name, manifest.Metadata.Version)
-			
+
 			if manifest.Metadata.Description != "" {
 				fmt.Printf("Description: %s\n", manifest.Metadata.Description)
 			}
-			
+
 			if manifest.Spec.Framework.Name != "" {
 				fmt.Printf("Framework:   %s", manifest.Spec.Framework.Name)
 				if manifest.Spec.Framework.Version != "" {
@@ -209,11 +209,11 @@ func infoCmd() *cobra.Command {
 				}
 				fmt.Println()
 			}
-			
+
 			if manifest.Metadata.License != "" {
 				fmt.Printf("License:     %s\n", manifest.Metadata.License)
 			}
-			
+
 			if len(manifest.Spec.Format.Files) > 0 {
 				fmt.Printf("\nFiles:\n")
 				totalSize := int64(0)


### PR DESCRIPTION
## Problem

The `axon info` command was using the old `registry.NewClient` approach, which only worked with a configured local registry. It failed for Hugging Face, PyTorch Hub, and TensorFlow Hub models, showing:

```
⚠ Model info not yet available (registry may not be configured)
```

## Solution

Updated `infoCmd` to use the adapter registry system, matching how `installCmd` works:

1. **Adapter Registry**: Registers all adapters in priority order (Local, PyTorch Hub, TensorFlow Hub, Hugging Face)
2. **Adapter Selection**: Uses `FindAdapter()` to find the correct adapter
3. **Manifest Fetching**: Uses `adapter.GetManifest()` instead of `client.GetManifest()`
4. **Enhanced Display**: Shows comprehensive model information including files and sizes

## Changes

- Replace old registry client with adapter registry system
- Register all adapters (Local, PyTorch Hub, TensorFlow Hub, Hugging Face)
- Use `adapter.GetManifest()` instead of `client.GetManifest()`
- Display comprehensive model information including files and sizes
- Add `formatBytes()` helper for human-readable file sizes

## Testing

✅ All adapters working:
- Hugging Face: `axon info hf/bert-base-uncased@latest`
- PyTorch Hub: `axon info pytorch/vision/resnet50@latest`
- TensorFlow Hub: `axon info tfhub/google/universal-sentence-encoder/4@latest`

## Example Output

```
Fetching info for hf/bert-base-uncased@latest...
Using huggingface adapter

📦 Model Information
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Name:        hf/bert-base-uncased@latest
Description: Model from Hugging Face: bert-base-uncased
Framework:   PyTorch 2.0.0
License:     Unknown

Files:
  - pytorch_model.bin (unknown)
```

Fixes the issue where 'axon info' showed 'Model info not yet available' for all models.