### PR TITLE
fix: Fix YAML syntax error on line 89 in docker-converter workflow

### DIFF
--- a/.github/workflows/docker-converter.yml
+++ b/.github/workflows/docker-converter.yml
@@ -86,4 +86,5 @@ jobs:
 
       - name: Image digest
         if: github.event_name != 'pull_request'
-        run: echo "Image digest: ${{ steps.build.outputs.digest }}"
+        run: |
+          echo "Image digest: ${{ steps.build.outputs.digest }}"


### PR DESCRIPTION
## Problem

GitHub Actions workflow validation is failing with a YAML syntax error on line 89:
```
Invalid workflow file
You have an error in your yaml syntax on line 89
```

The error is: `mapping values are not allowed here` at column 32, which is where the `${{ }}` expression starts.

## Root Cause

GitHub Actions YAML parser requires multi-line format for `run:` commands that contain `${{ }}` expressions. Single-line format with `${{ }}` expressions can cause parsing issues.

## Solution

Changed the `run:` command from single-line to multi-line format:
```yaml
# Before (causes error)
run: echo "Image digest: ${{ steps.build.outputs.digest }}"

# After (fixed)
run: |
  echo "Image digest: ${{ steps.build.outputs.digest }}"
```

## Local Validation

- ✅ YAML syntax validated with Python yaml parser
- ✅ Workflow file structure validated
- ✅ All YAML files pass validation

## Testing

- ✅ Created from synced main branch
- ✅ Local validation passes
- ✅ Ready for GitHub Actions validation