### PR TITLE
fix: Only trigger Docker workflow on published releases

### DIFF
--- a/.github/workflows/docker-converter.yml
+++ b/.github/workflows/docker-converter.yml
@@ -2,7 +2,7 @@ name: Build and Publish Docker Converter Image
 
 on:
   release:
-    types: [ published, created ]
+    types: [ published ]
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Problem

The Docker workflow is running twice for each release:
- Once on `created` event (when release is created)
- Once on `published` event (when release is published)

When you create a release as published, GitHub emits both events, causing duplicate builds.

## Solution

Removed `created` trigger type, keeping only `published`:
- `published` is when the release is actually available
- `created` happens for draft releases too (we don't want to build for drafts)
- Prevents duplicate workflow runs

## Changes

```yaml
# Before
on:
  release:
    types: [ published, created ]

# After
on:
  release:
    types: [ published ]
```

## Benefits

- ✅ No duplicate builds
- ✅ Reduced CI costs
- ✅ Only builds for published releases (not drafts)
- ✅ Cleaner workflow execution

## Testing

- ✅ YAML syntax validated
- ✅ Workflow structure validated