### PR TITLE
fix: Handle nested namespace model IDs in temp file paths

### DIFF
--- a/cmd/axon/commands_test.go
+++ b/cmd/axon/commands_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestSafeTempFileName(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		modelName string
+		version   string
+		expected  string
+	}{
+		{
+			name:      "simple namespace",
+			namespace: "hf",
+			modelName: "distilgpt2",
+			version:   "latest",
+			expected:  "hf-distilgpt2-latest.axon",
+		},
+		{
+			name:      "nested namespace with one slash",
+			namespace: "hf/microsoft",
+			modelName: "resnet-50",
+			version:   "latest",
+			expected:  "hf_microsoft-resnet-50-latest.axon",
+		},
+		{
+			name:      "nested namespace with multiple slashes",
+			namespace: "hf/google/research",
+			modelName: "vit-base",
+			version:   "1.0.0",
+			expected:  "hf_google_research-vit-base-1.0.0.axon",
+		},
+		{
+			name:      "model name with slash",
+			namespace: "pytorch",
+			modelName: "vision/resnet50",
+			version:   "latest",
+			expected:  "pytorch-vision_resnet50-latest.axon",
+		},
+		{
+			name:      "version with slash",
+			namespace: "hf",
+			modelName: "bert",
+			version:   "v1/beta",
+			expected:  "hf-bert-v1_beta.axon",
+		},
+		{
+			name:      "backslash handling",
+			namespace: "hf\\microsoft",
+			modelName: "resnet\\50",
+			version:   "latest",
+			expected:  "hf_microsoft-resnet_50-latest.axon",
+		},
+		{
+			name:      "empty namespace",
+			namespace: "",
+			modelName: "model",
+			version:   "1.0",
+			expected:  "-model-1.0.axon",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := safeTempFileName(tt.namespace, tt.modelName, tt.version)
+			if result != tt.expected {
+				t.Errorf("safeTempFileName(%q, %q, %q) = %q, expected %q",
+					tt.namespace, tt.modelName, tt.version, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #38

Model IDs with nested namespaces (e.g., `hf/microsoft/resnet-50`) would fail to install because the `/` in the namespace created a nested directory path in `/tmp` that didn't exist.

## Problem
```bash
axon install hf/microsoft/resnet-50@latest
# Error: failed to create package file: open /tmp/hf/microsoft-resnet-50-latest.axon: no such file or directory
```

## Solution
Add `safeTempFileName()` helper that encodes path separators (`/` and `\`) as underscores for temp file names only.

```go
// Before: creates nested path that doesn't exist
/tmp/hf/microsoft-resnet-50-latest.axon

// After: flat path that works
/tmp/hf_microsoft-resnet-50-latest.axon
```

## Key Design Decision
**Only the temp file name is affected** - the model ID used in APIs, cache paths, and user-facing commands remains unchanged. This ensures:
- ✅ No breaking changes to API
- ✅ No changes to user workflow
- ✅ Cache paths still use nested directories (handled by `os.MkdirAll`)

## Testing
- Added 7 test cases covering:
  - Simple namespace
  - Nested namespace (one slash)
  - Deeply nested namespace (multiple slashes)
  - Slashes in model name
  - Slashes in version
  - Backslash handling (Windows)
  - Empty namespace

- Local testing with `hf/microsoft/resnet-50@latest` - download succeeds

## CI Checks
```
✅ go vet: passed
✅ golangci-lint (v1.64.8): passed
✅ go test: passed (7/7 safeTempFileName tests)
✅ go build: passed
```