### PR TITLE
feat: Add execution_files to manifest for explicit model paths

### DIFF
--- a/pkg/types/manifest.go
+++ b/pkg/types/manifest.go
@@ -53,10 +53,19 @@ type Framework struct {
 
 // Format describes the model file format
 type Format struct {
-	Type            string      `yaml:"type" json:"type"`                                       // Original format (pytorch, tensorflow)
-	ExecutionFormat string      `yaml:"execution_format" json:"execution_format"`               // Execution format (onnx, pytorch, tensorflow)
-	MultiEncoder    string      `yaml:"multi_encoder,omitempty" json:"multi_encoder,omitempty"` // Architecture for multi-encoder models (clip, seq2seq)
-	Files           []ModelFile `yaml:"files" json:"files"`
+	Type            string          `yaml:"type" json:"type"`                                       // Original format (pytorch, tensorflow)
+	ExecutionFormat string          `yaml:"execution_format" json:"execution_format"`               // Execution format (onnx, gguf, tflite, etc.)
+	MultiEncoder    string          `yaml:"multi_encoder,omitempty" json:"multi_encoder,omitempty"` // Architecture for multi-encoder models (clip, seq2seq)
+	Files           []ModelFile     `yaml:"files" json:"files"`
+	ExecutionFiles  []ExecutionFile `yaml:"execution_files,omitempty" json:"execution_files,omitempty"` // Explicit paths for execution files (ONNX, GGUF, etc.)
+}
+
+// ExecutionFile represents a model file for execution by Core
+// Supports any format: ONNX, GGUF, TFLite, CoreML, etc.
+type ExecutionFile struct {
+	Path   string `yaml:"path" json:"path"`     // Relative path from model root (e.g., "onnx/model.onnx", "model.Q4_K_M.gguf")
+	Format string `yaml:"format" json:"format"` // File format: "onnx", "gguf", "tflite", "coreml", etc.
+	Type   string `yaml:"type" json:"type"`     // Role: "single", "encoder", "decoder", "text_encoder", "vision_encoder"
 }
 
 // ModelFile represents a file in the model package


### PR DESCRIPTION
## Summary

Add format-agnostic `execution_files` field to manifest that provides explicit paths for Core to use, eliminating directory guessing.

### Changes

- Add `ExecutionFile` struct to `types/manifest.go` with path, format, type fields
- Add `ExecutionFiles` slice to `Format` struct
- Add `populateExecutionFiles()` in `commands.go` to discover files after install
- Support ONNX, GGUF, TFLite, CoreML formats
- Handle multi-encoder models (seq2seq, CLIP) with proper type detection

### Manifest Example

The `execution_files` field in `manifest.yaml` now looks like:

```yaml
spec:
  format:
    type: onnx
    execution_format: onnx
    execution_files:
      - path: onnx/model.onnx
        format: onnx
        type: single
      - path: onnx/model_O1.onnx
        format: onnx
        type: single
```

### Benefits

- **Eliminates path guessing**: Core reads paths directly from manifest
- **Format agnostic**: Works with ONNX, GGUF, TFLite, CoreML
- **Multi-encoder support**: Properly identifies encoder/decoder roles
- **Fixes CI failures**: Models like sentence-transformers with ONNX in onnx/ subdirectory now work

### Testing

- Verified with sentence-transformers model
- All existing tests pass
- Builds successfully

Resolves: #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)