### PR TITLE
feat: Add --format flag for target execution format control

### DIFF
--- a/internal/converter/onnx.go
+++ b/internal/converter/onnx.go
@@ -451,6 +451,24 @@ func IsExecutionReadyWithPath(format string, modelPath string) bool {
 		}
 		return false
 
+	case "pytorch", "torchscript":
+		// Check for actual .pt/.pth files (TorchScript models)
+		entries, err := os.ReadDir(modelPath)
+		if err != nil {
+			return false
+		}
+		for _, entry := range entries {
+			nameLower := strings.ToLower(entry.Name())
+			if strings.HasSuffix(nameLower, ".pt") || strings.HasSuffix(nameLower, ".pth") {
+				// Verify file is non-empty
+				filePath := filepath.Join(modelPath, entry.Name())
+				if info, err := os.Stat(filePath); err == nil && info.Size() > 0 {
+					return true
+				}
+			}
+		}
+		return false
+
 	default:
 		// Other formats need conversion
 		return false


### PR DESCRIPTION
## Summary

Add `--format` flag to `axon install` command to control target execution format, enabling support for Core's format-agnostic runtime plugin system (Core PR #51).

### Changes

| File | Changes |
|------|---------|
| `cmd/axon/commands.go` | Add --format flag with options: auto, pytorch, onnx, gguf, native |
| `internal/converter/onnx.go` | Add PyTorch/TorchScript format detection for .pt/.pth files |

### Supported Formats

| Format | Description | Core Plugin |
|--------|-------------|-------------|
| `auto` | Auto-detect best format (default) | - |
| `onnx` | Convert to ONNX | onnx_runtime |
| `pytorch` | Keep native PyTorch/TorchScript | pytorch_runtime |
| `gguf` | Use GGUF for LLMs | gguf_runtime |
| `native` | Skip all conversion | auto-detect |

### Usage Examples

```bash
# Default: convert to ONNX
axon install hf/microsoft/resnet-50@latest

# Keep native PyTorch format (for pytorch_runtime plugin)
axon install hf/microsoft/resnet-50@latest --format pytorch

# Use GGUF for LLMs
axon install hf/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF@latest --format gguf

# Skip all conversion
axon install hf/my-model@v1 --format native
```

### Related PRs

- Core PR #51: SMI v1.1 centralized output serialization & PyTorch runtime plugin
- system-test PR #35: Extended model support (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)