### PR TITLE
fix: Use absolute container paths in Docker ONNX converter

### DIFF
--- a/internal/converter/docker.go
+++ b/internal/converter/docker.go
@@ -145,15 +145,19 @@ func ConvertToONNXWithDocker(ctx context.Context, modelPath, framework, namespac
 	// Build Docker command
 	// Volume mapping: host cache dir -> /axon/cache in container
 	// Working directory: /axon/cache (so relative paths work)
+	// IMPORTANT: Use absolute container paths to avoid Optimum/HuggingFace
+	// misinterpreting relative paths like "latest" as model IDs
+	containerModelPath := "/axon/cache/" + relModelPath
+	containerOutputPath := "/axon/cache/" + relOutputPath
 	dockerArgs := []string{
 		"run", "--rm",
 		"-v", fmt.Sprintf("%s:/axon/cache", absCacheDir),
 		"-w", "/axon/cache",
 		imageName,
 		fmt.Sprintf("/axon/scripts/%s", scriptName),
-		relModelPath,  // Model path (relative to cache)
-		relOutputPath, // Output path (relative to cache)
-		modelID,       // Model ID for repository lookup
+		containerModelPath,  // Absolute container path to model
+		containerOutputPath, // Absolute container path for output
+		modelID,             // Model ID for repository lookup (e.g., "microsoft/resnet-50")
 	}
 
 	fmt.Printf("🐳 Converting model using Docker (%s)...\n", imageName)

--- a/scripts/conversion/convert_huggingface.py
+++ b/scripts/conversion/convert_huggingface.py
@@ -828,10 +828,10 @@ if __name__ == "__main__":
     if len(sys.argv) != 4:
         print("Usage: convert_huggingface.py <model_path> <output_path> <model_id>")
         sys.exit(1)
-    
+
     model_path = sys.argv[1]
     output_path = sys.argv[2]
     axon_model_id = sys.argv[3]
-    
+
     success = convert_huggingface_to_onnx(model_path, output_path, axon_model_id)
     sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary
Fix ONNX conversion for HuggingFace models like `microsoft/resnet-50` that don't have pre-exported ONNX files on HuggingFace Hub.

## Problem
When converting models using Docker, relative paths like `latest` were being passed to the Python conversion script. When Optimum's `main_export()` received such paths, it would sometimes misinterpret them as HuggingFace model IDs, causing errors like:
```
OSError: resnet-50 is not a local folder and is not a valid model identifier
```

## Root Cause
The Docker volume mount maps the model's parent directory to `/axon/cache` in the container. When we passed `relModelPath = "latest"` (the version directory name), Optimum would:
1. Check if "latest" is a directory - yes it exists
2. Try to load the model from that directory
3. If loading failed, fall back to treating "latest" as a HuggingFace model ID
4. Fail because "latest" is not a valid model ID

## Solution
Use absolute container paths (`/axon/cache/latest`) instead of relative paths (`latest`) when invoking the conversion script inside Docker. This ensures Optimum correctly identifies the path as a local directory.

## Changes
- `internal/converter/docker.go`: Build absolute container paths for model and output directories
- `scripts/conversion/convert_huggingface.py`: Minor whitespace cleanup

## Testing
Tested on Ubuntu VM with full E2E pipeline:

| Model | Install | Register | Inference | Result |
|-------|---------|----------|-----------|--------|
| hf/microsoft/resnet-50 | ✅ | ✅ | ✅ | PASS |
| hf/bert-base-uncased | ✅ | ✅ | ✅ | PASS |
| hf/distilgpt2 | ✅ | ✅ | ✅ | PASS |

## Test plan
- [x] Fresh install of `hf/microsoft/resnet-50` converts to ONNX successfully
- [x] E2E inference test passes with small and large inputs
- [x] Output validation passes (3 tests)
- [x] Existing models (BERT, GPT-2) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)